### PR TITLE
Use the whitespace analyzer for synonym rule validation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group = io.bonsai
-publishedPluginVersion=1.0.0
-pluginVersion=1.0.0
+publishedPluginVersion=1.0.1
+pluginVersion=1.0.1
 esVersion=7.7.1
 pluginName=stored-synonyms
 pluginClassname=io.bonsai.plugins.synonyms.StoredSynonymsPlugin

--- a/src/main/java/io/bonsai/plugins/synonyms/StoredSynonyms.java
+++ b/src/main/java/io/bonsai/plugins/synonyms/StoredSynonyms.java
@@ -7,7 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.core.SimpleAnalyzer;
+import org.apache.lucene.analysis.core.WhitespaceAnalyzer;
 import org.apache.lucene.analysis.synonym.SolrSynonymParser;
 import org.apache.lucene.analysis.synonym.SynonymMap;
 import org.elasticsearch.rest.RestStatus;
@@ -66,7 +66,7 @@ public class StoredSynonyms {
   public static void validate(StoredSynonyms synonyms) {
     SynonymMap map;
     try {
-      map = parseSynonymMap(new SimpleAnalyzer(), synonyms.getRules());
+      map = parseSynonymMap(new WhitespaceAnalyzer(), synonyms.getRules());
     } catch (Exception error) {
       throw new StoredSynonymsException(error, RestStatus.UNPROCESSABLE_ENTITY);
     }

--- a/src/test/java/io/bonsai/plugins/synonyms/RestTests.java
+++ b/src/test/java/io/bonsai/plugins/synonyms/RestTests.java
@@ -62,8 +62,7 @@ public class RestTests extends BaseClusterTest {
             .body(getResourceStr("files/invalid_synonyms.json"))
             .execute()) {
       Assert.assertEquals(422, curlResponse.getHttpStatusCode());
-      Assert.assertTrue(
-          curlResponse.getContentAsString().contains("Invalid synonym rule at line 1"));
+      Assert.assertTrue(curlResponse.getContentAsString().contains("No rules accepted"));
     }
   }
 }

--- a/src/test/resources/files/invalid_synonyms.json
+++ b/src/test/resources/files/invalid_synonyms.json
@@ -1,6 +1,6 @@
 {
   "name": "test",
   "rules": [
-    "fancy,],pants,["
+    ",=>,....,,,,,,"
   ]
 }


### PR DESCRIPTION
Validation was failing due to certain tokens, like numbers, being eliminated.