### PR TITLE
Fix cluster wide invalidation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group = io.bonsai
-publishedPluginVersion=1.0.1
-pluginVersion=1.0.1
+publishedPluginVersion=1.0.2
+pluginVersion=1.0.2
 esVersion=7.7.1
 pluginName=stored-synonyms
 pluginClassname=io.bonsai.plugins.synonyms.StoredSynonymsPlugin

--- a/src/main/java/io/bonsai/plugins/synonyms/SynonymsTransportInvalidateAction.java
+++ b/src/main/java/io/bonsai/plugins/synonyms/SynonymsTransportInvalidateAction.java
@@ -200,6 +200,7 @@ public class SynonymsTransportInvalidateAction
 
     public NodeRequest(StreamInput in) throws IOException {
       super(in);
+      request = new InvalidateRequest(in);
     }
 
     public NodeRequest(final InvalidateRequest request) {

--- a/src/test/java/io/bonsai/plugins/synonyms/AnalysisTests.java
+++ b/src/test/java/io/bonsai/plugins/synonyms/AnalysisTests.java
@@ -59,11 +59,6 @@ public class AnalysisTests extends BaseClusterTest {
       Assert.assertEquals(200, curlResponse.getHttpStatusCode());
     }
 
-    //    cluster.refresh();
-    //    Thread.sleep(100);
-
-    System.err.println("Pre assert search");
-
     response =
         cluster.search(
             "myindex",
@@ -84,9 +79,6 @@ public class AnalysisTests extends BaseClusterTest {
             .execute()) {
       Assert.assertEquals(200, curlResponse.getHttpStatusCode());
     }
-
-    //    cluster.refresh();
-    //    Thread.sleep(100);
 
     response =
         cluster.search(

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Logger name="org.elasticsearch" level="warn">
+      <AppenderRef ref="Console"/>
+    </Logger>
+    <Root level="DEBUG">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>


### PR DESCRIPTION
The deserialization of the invalidation payload was not actually
constructing the InvalidateRequest from the payload, which caused
the handling node to kill the connection.  The coordinating node
was also silently dropping the errors.